### PR TITLE
fixes #271

### DIFF
--- a/components/PlaylistTopBarExtraField/PlaylistTopBarExtraField.tsx
+++ b/components/PlaylistTopBarExtraField/PlaylistTopBarExtraField.tsx
@@ -43,6 +43,7 @@ export default function PlaylistTopBarExtraField({
           align-items: center;
           display: flex;
           white-space: nowrap;
+          max-width: 100%;
         }
       `}</style>
     </div>


### PR DESCRIPTION
#271 Parent element needs a maximum width for overflow: hidden to take effect in the children.

![image](https://github.com/MarcoMadera/Rindu/assets/31965686/01990242-0645-4080-8cf9-162ffa973b09)
![image](https://github.com/MarcoMadera/Rindu/assets/31965686/16c6b367-3a70-4ac5-b11b-b54e28d14c0d)

In <768px wide devices it doesn't have any effects.

```
Test Suites: 49 passed, 49 total
Tests:       180 passed, 180 total
Snapshots:   0 total
Time:        16.545 s
Ran all test suites.
```